### PR TITLE
Give better support for cache and home folder

### DIFF
--- a/src/Insulin/Console/KernelInterface.php
+++ b/src/Insulin/Console/KernelInterface.php
@@ -161,6 +161,17 @@ interface KernelInterface extends \Serializable
     public function getStartTime();
 
     /**
+     * Returns Insulin home directory for storage of cache and other related
+     * data.
+     *
+     * @return string
+     *   The Insulin home directory.
+     *
+     * @api
+     */
+    public function getHomeDir();
+
+    /**
      * Gets the cache directory.
      *
      * @return string
@@ -169,16 +180,6 @@ interface KernelInterface extends \Serializable
      * @api
      */
     public function getCacheDir();
-
-    /**
-     * Gets the log directory.
-     *
-     * @return string
-     *   The log directory.
-     *
-     * @api
-     */
-    public function getLogDir();
 
     /**
      * Gets the charset of the application.


### PR DESCRIPTION
The location for cache defaults to `~/.insulin/cache` on *nix and
`%LOCALAPPDATA%\Insulin\cache` on windows.

When getting the home directory, we also protect it against web access, since
HOME can be the www-data's user home and be web-accessible.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
