### PR TITLE
Support more verbose levels and better debugging

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     ],
     "autoload": {
         "psr-0": {
-            "": "src/"
+            "Insulin": "src/",
+            "Sugar": "src/"
         }
     },
     "require": {
@@ -33,6 +34,7 @@
         "symfony/config": "2.3.*",
         "symfony/console": "2.3.*",
         "symfony/dependency-injection": "2.3.*",
+        "symfony/event-dispatcher": "2.3",
         "symfony/finder": "2.3.*",
         "symfony/locale": "2.3.*",
         "symfony/process": "2.3.*"

--- a/src/Insulin/Console/DebugSubscriber.php
+++ b/src/Insulin/Console/DebugSubscriber.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Insulin CLI
+ *
+ * Copyright (c) 2008-2013 Filipe Guerra, João Morais
+ * http://cli.sugarmeetsinsulin.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Insulin\Console;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class DebugSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var OutputInterface we are going to log to the output of the App.
+     */
+    protected $output;
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::BOOT_SUCCESS => array(
+                array('onKernelBootSuccess'),
+            ),
+            KernelEvents::BOOT_FAILURE => array(
+                array('onKernelBootFailure'),
+            ),
+        );
+    }
+
+    /**
+     * The Debug Subscriber will show debug messages based on events that are
+     * being triggered by the core application or kernel.
+     *
+     * @param OutputInterface $output
+     *   The output where we are going to debug to.
+     */
+    public function __construct(OutputInterface $output)
+    {
+        $this->output = $output;
+    }
+
+    /**
+     * Listen for Kernel boot success levels.
+     *
+     * @param KernelBootEvent $event
+     *   The event that contains the level that was booted successfully.
+     */
+    public function onKernelBootSuccess(KernelBootEvent $event)
+    {
+        $this->output->writeln(
+            sprintf("Max phase reached '%d'.", $event->getLevel())
+        );
+    }
+
+    /**
+     * Listen for possible Kernel boot failures.
+     *
+     * @param KernelBootEvent $event
+     *   The event that contains the boot failure.
+     */
+    public function onKernelBootFailure(KernelBootEvent $event)
+    {
+        $this->output->writeln(
+            sprintf(
+                "Unable to reach '%d' phase due to: %s",
+                $event->getLevel(),
+                $event->getError()
+            )
+        );
+    }
+}

--- a/src/Insulin/Console/KernelBootEvent.php
+++ b/src/Insulin/Console/KernelBootEvent.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Insulin CLI
+ *
+ * Copyright (c) 2008-2013 Filipe Guerra, João Morais
+ * http://cli.sugarmeetsinsulin.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Insulin\Console;
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * KernelBootEvent contains the Kernel Boot event data.
+ *
+ * @see KernelEvents for a list of possible event names that trigger this
+ *   event.
+ * @see Kernel::boot to see how this event is triggered.
+ *
+ * @api
+ */
+class KernelBootEvent extends Event
+{
+    /**
+     * The Boot level that triggered this event.
+     *
+     * @var int
+     */
+    protected $level;
+
+    /**
+     * The error message from the exception when a failure happens.
+     *
+     * @var string
+     */
+    protected $error;
+
+    /**
+     * Creates a new instance with the boot level and the error message if an
+     * error occurred.
+     *
+     * @param int $level
+     *   The Kernel's boot level.
+     * @param string $error
+     *   The Kernel's error message if failure (defaults to empty).
+     */
+    public function __construct($level, $error = '')
+    {
+        $this->level = $level;
+        $this->error = $error;
+    }
+
+    /**
+     * Gets the Kernel's boot level that triggered this event.
+     *
+     * @return int
+     *   The Kernel's boot level defined on this event.
+     */
+    public function getLevel()
+    {
+        return $this->level;
+    }
+
+    /**
+     * Gets the error message explaining why the Kernel failed to boot.
+     *
+     * @return int
+     *   The Kernel's error message if boot failed.
+     */
+    public function getError()
+    {
+        return $this->error;
+    }
+}

--- a/src/Insulin/Console/KernelEvents.php
+++ b/src/Insulin/Console/KernelEvents.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Insulin CLI
+ *
+ * Copyright (c) 2008-2013 Filipe Guerra, João Morais
+ * http://cli.sugarmeetsinsulin.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Insulin\Console;
+
+final class KernelEvents
+{
+    /**
+     * The `kernel.boot_success` event is thrown each time the boot reaches a
+     * certain level with success.
+     *
+     * The event listener receives an
+     * Insulin\Console\KernelBootEvent instance.
+     *
+     * @var string
+     */
+    const BOOT_SUCCESS = 'kernel.boot_success';
+
+    /**
+     * The `kernel.boot_failure` event is thrown each time the boot fails on a
+     * certain level.
+     *
+     * The event listener receives an
+     * Insulin\Console\KernelBootEvent instance.
+     *
+     * @var string
+     */
+    const BOOT_FAILURE = 'kernel.boot_failure';
+}

--- a/src/Insulin/Console/KernelInterface.php
+++ b/src/Insulin/Console/KernelInterface.php
@@ -85,6 +85,13 @@ interface KernelInterface extends \Serializable
     const BOOT_SUGAR_LOGIN = 6;
 
     /**
+     * Initializes the current kernel.
+     *
+     * @api
+     */
+    public function initialize();
+
+    /**
      * Boots the current kernel.
      *
      * @api


### PR DESCRIPTION
Now we have up to 3 levels of verbose and 1 debugging. Use the 3rd level for
Application debugging and the debug flag to support kernel profiling (memory
and time spent to execute the command).

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |

Requires https://github.com/insulin/cli/pull/39 to be merged first.
