### PR TITLE
[Core] Kernel's boot method shouldn't return booted level

### DIFF
--- a/src/Insulin/Console/Kernel.php
+++ b/src/Insulin/Console/Kernel.php
@@ -150,7 +150,7 @@ class Kernel extends ContainerAware implements KernelInterface
     public function boot()
     {
         if ($this->booted) {
-            return $this->bootedLevel;
+            return;
         }
 
         $this->initialize();
@@ -179,8 +179,14 @@ class Kernel extends ContainerAware implements KernelInterface
             KernelEvents::BOOT_SUCCESS,
             new KernelBootEvent($this->bootedLevel)
         );
+    }
 
-        return $this->bootedLevel;
+    /**
+     * {@inheritdoc}
+     */
+    public function getBootedLevel()
+    {
+        return $this->isBooted() ? $this->bootedLevel : false;
     }
 
     /**

--- a/src/Insulin/Console/KernelInterface.php
+++ b/src/Insulin/Console/KernelInterface.php
@@ -99,6 +99,19 @@ interface KernelInterface extends \Serializable
     public function boot();
 
     /**
+     * Returns the maximum level reached after booting with success, false
+     * otherwise.
+     *
+     * All levels available are defined as BOOT_* constants on KernelInterface.
+     *
+     * @return bool|int
+     *   The current boot level of the kernel.
+     *
+     * @api
+     */
+    public function getBootedLevel();
+
+    /**
      * Shutdowns the kernel.
      *
      * This method is mainly useful when doing functional testing.

--- a/src/Insulin/Console/Tests/KernelTest.php
+++ b/src/Insulin/Console/Tests/KernelTest.php
@@ -114,9 +114,9 @@ class KernelTest extends \PHPUnit_Framework_TestCase
         $debug = true;
 
         $kernel = new Kernel($debug);
-        $bootedLevel = $kernel->boot();
+        $kernel->boot();
 
-        $this->assertSame(Kernel::BOOT_INSULIN, $bootedLevel);
+        $this->assertSame(Kernel::BOOT_INSULIN, $kernel->getBootedLevel());
         $this->assertTrue($kernel->isBooted());
     }
 
@@ -149,9 +149,9 @@ class KernelTest extends \PHPUnit_Framework_TestCase
             $kernel->setSugarPath('/path/to/sugar');
         }
 
-        $bootedLevel = $kernel->boot();
+        $kernel->boot();
 
-        $this->assertSame(Kernel::BOOT_SUGAR_ROOT, $bootedLevel);
+        $this->assertSame(Kernel::BOOT_SUGAR_ROOT, $kernel->getBootedLevel());
         $this->assertTrue($kernel->isBooted());
     }
 


### PR DESCRIPTION
On KernelInterface there is no documentation that boot returns booted level, 
therefore should be removed and since we need this, we added an extra method 
to get it, if needed.
