### PR TITLE
[Core] Kernel failure should only happen when no boot level was reached

### DIFF
--- a/src/Insulin/Console/Tests/KernelTest.php
+++ b/src/Insulin/Console/Tests/KernelTest.php
@@ -109,6 +109,29 @@ class KernelTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * Confirm that boot fails when not reaching first level.
+     *
+     * @expectedException \Exception
+     * @expectedExceptionMessage Unit test for boot failure
+     */
+    public function testBootFailure()
+    {
+        $kernel = $this->getMock(
+            'Insulin\Console\Kernel',
+            array('getBootstrapLevels', 'bootTo')
+        );
+
+        $kernel->expects($this->once())->method('getBootstrapLevels')->will(
+            $this->returnValue(array(1))
+        );
+        $kernel->expects($this->once())->method('bootTo')->with(1)->will(
+            $this->throwException(new \Exception('Unit test for boot failure'))
+        );
+
+        $kernel->boot();
+    }
+
     public function testBootInsulinLevel()
     {
         $debug = true;


### PR DESCRIPTION
Kernel failure shouldn't be happening on any boot level failure. For that
there will be other levels/events that should be added.
