### PR TITLE
[Core] Unable to boot Sugar to BOOT_SUGAR_FULL level

### DIFF
--- a/src/Insulin/Sugar/Sugar.php
+++ b/src/Insulin/Sugar/Sugar.php
@@ -175,7 +175,7 @@ abstract class Sugar implements SugarInterface
         global $locale;
         global $db;
         global $beanList;
-        // global $beanFiles;
+        global $beanFiles;
         // global $moduleList;
         // global $modInvisList;
         // global $adminOnlyList;


### PR DESCRIPTION
The Quotes module uses `$beanFiles` on `require_once` on the top of the class
file.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
