### PR TITLE
[WIP] Create status command

### DIFF
--- a/src/Insulin/Console/Command/StatusCommand.php
+++ b/src/Insulin/Console/Command/StatusCommand.php
@@ -1,0 +1,247 @@
+<?php
+
+/*
+ * This file is part of the Insulin CLI
+ *
+ * Copyright (c) 2008-2013 Filipe Guerra, João Morais
+ * http://cli.sugarmeetsinsulin.com
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Insulin\Console\Command;
+
+use Insulin\Sugar\SugarInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\TableHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * This command provides information about the current status of Insulin and
+ * SugarCRM version on existing or provided path.
+ *
+ * The information provided depends on the maximum boot level reached.
+ *
+ * @fixme Insulin commands need to extend from InsulinCommand so it requires an Insulin Application
+ *
+ * @api
+ */
+class StatusCommand extends Command
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('status')
+            ->setAliases(array('st'))
+            ->setDefinition(array(
+                new InputOption('show-passwords', null, InputOption::VALUE_NONE, 'Show database password.'),
+                new InputOption('format', null, InputOption::VALUE_REQUIRED, 'To output status in other formats.', 'table'),
+            ))
+            ->setDescription('Provides a birds-eye view of the current SugarCRM installation, if any.')
+            ->setHelp(
+                <<<EOF
+The <info>%command.name%</info> command shows the current SugarCRM status:
+
+  <info>%command.full_name%</info>
+
+You can also output the status in other formats by using the <comment>--format</comment> option:
+
+  <info>%command.full_name% --format=json</info>
+
+Output formats available: <comment>table</comment>, <comment>json</comment>.
+EOF
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Uses table helper for output.
+     * @see http://symfony.com/doc/master/components/console/helpers/tablehelper.html
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $data =
+            $this->getInsulinInfo() +
+            $this->getSugarBasicInfo() +
+            $this->getSugarConfigurationInfo() +
+            $this->getSugarMoreInfo();
+
+        if (!$input->hasOption('show-passwords')) {
+            unset($data['Database password']);
+            unset($data['License download key']);
+        }
+
+        // TODO sorting by translated labels for table format
+        ksort($data);
+
+        switch ($input->getOption('format')) {
+            case 'table':
+
+                /* @var $table TableHelper */
+                $table = $this->getApplication()->getHelperSet()->get('table');
+                $table->setLayout(TableHelper::LAYOUT_COMPACT);
+
+                // prepare data for TableHelper
+                // TODO move this to a class so we can reuse this type of output (e.g: for vardefs)
+                foreach ($data as $key => $value) {
+
+                    // do some fixes based on keys
+                    if ($key === 'Database') {
+                        $value = $value ? 'Connected' : 'Not connected';
+                    } elseif (is_bool($value)) {
+                        $value = $value ? 'Enabled' : 'Disabled';
+                    }
+
+                    $table->addRow(array($key, $value));
+                }
+
+                $table->render($output);
+
+                break;
+            case 'json':
+                $output->writeln(json_encode($data));
+                break;
+            default:
+                throw new \InvalidArgumentException(sprintf('Unsupported format "%s".', $input->getOption('format')));
+        }
+    }
+
+    protected function getInsulinInfo()
+    {
+        /* @var $kernel \Insulin\Console\KernelInterface */
+        $kernel = $this->getApplication()->getKernel();
+
+        if ($kernel->getBootedLevel() < $kernel::BOOT_INSULIN) {
+            return array();
+        }
+
+        return array(
+            // not the same but probably we shouldn't give too much support for 5.3 now that 5.5 is out
+            'PHP executable' => defined('PHP_BINARY') ? PHP_BINARY : PHP_BINDIR,
+            'PHP configuration' => php_ini_loaded_file(),
+            'PHP OS' => PHP_OS,
+            'Insulin version' => $kernel->getVersion(),
+        );
+
+    }
+
+    protected function getSugarBasicInfo()
+    {
+        /* @var $kernel \Insulin\Console\KernelInterface */
+        $kernel = $this->getApplication()->getKernel();
+
+        if ($kernel->getBootedLevel() < $kernel::BOOT_SUGAR_ROOT) {
+            return array();
+        }
+
+        /* @var $sugar SugarInterface */
+        $sugar = $kernel->get('sugar');
+
+        $flavor = $sugar->getInfo('flavor');
+        $version = $sugar->getInfo('version');
+        $build = $sugar->getInfo('build');
+
+        return array(
+            'SugarCRM version' => sprintf('%s %s build %s', $flavor, $version, $build),
+            'SugarCRM root' => $sugar->getPath(),
+        );
+    }
+
+    protected function getSugarConfigurationInfo()
+    {
+        /* @var $kernel \Insulin\Console\KernelInterface */
+        $kernel = $this->getApplication()->getKernel();
+
+        if ($kernel->getBootedLevel() < $kernel::BOOT_SUGAR_CONFIGURATION) {
+            return array();
+        }
+
+        /* @var $sugar SugarInterface */
+        $sugar = $kernel->get('sugar');
+
+        // FIXME we need a getConfig as API from SugarInterface
+        $config = $sugar->bootConfig();
+
+        $dbType = $config['dbconfig']['db_type'];
+        $dbHostname = $config['dbconfig']['db_host_name'];
+        $dbPort = $config['dbconfig']['db_port'];
+        $dbUsername = $config['dbconfig']['db_user_name'];
+        $dbPassword = $config['dbconfig']['db_password'];
+        $dbName = $config['dbconfig']['db_name'];
+
+        $data = array(
+            'Database driver' => $dbType,
+            'Database hostname' => $dbHostname,
+            'Database port' => $dbPort,
+            'Database username' => $dbUsername,
+            'Database password' => $dbPassword,
+            'Database name' => $dbName,
+        );
+
+        $isConnected = ($kernel->getBootedLevel() >= $kernel::BOOT_SUGAR_DATABASE);
+        $data += array(
+            'Database' => $isConnected,
+        );
+
+        $data += array(
+            'Cache directory path' => $config['cache_dir'],
+            'Site URI' => $config['site_url'],
+            'Upload directory path' => $config['upload_dir'],
+            'Developer mode' => !empty($config['developerMode']),
+            'Logger level' => $config['logger']['level'],
+            // FIXME support SugarCRM logger file with dates
+            // see sugarcrm/include/SugarLogger/SugarLogger.php on _doInitialization
+            'Logger file' => $config['logger']['file']['name'] . $config['logger']['file']['ext'],
+        );
+
+        if (!empty($config['full_text_engine'])) {
+            // TODO this is weird but I'm pretty sure that Sugar only supports 1 FTS at a time
+            // but configuration gets this as an array?
+            $ftsEngine = reset($config['full_text_engine']);
+            $data += array(
+                'Full text engine' => key($config['full_text_engine']),
+                'Full text engine host' => $ftsEngine['host'],
+                'Full text engine port' => $ftsEngine['port'],
+            );
+        }
+
+        return $data;
+    }
+
+    protected function getSugarMoreInfo()
+    {
+        /* @var $kernel \Insulin\Console\KernelInterface */
+        $kernel = $this->getApplication()->getKernel();
+
+        if ($kernel->getBootedLevel() < $kernel::BOOT_SUGAR_FULL) {
+            return array();
+        }
+
+        /* @var $sugar SugarInterface */
+        $sugar = $kernel->get('sugar');
+        $settings = $sugar->getSystemSettings('info');
+
+        $data = array(
+            'Database expected version' => $settings['info_sugar_version'],
+        );
+
+        if ($sugar->getInfo('flavor') !== 'COM') {
+            $data += array(
+                'License number of users' => $settings['license_users'],
+                'License number of offline clients' => $settings['license_num_lic_oc'],
+                'License expire date' => $settings['license_expire_date'],
+                'License download key' => $settings['license_key'],
+            );
+        }
+
+        return $data;
+    }
+}

--- a/src/Insulin/Sugar/Sugar.php
+++ b/src/Insulin/Sugar/Sugar.php
@@ -223,4 +223,14 @@ abstract class Sugar implements SugarInterface
             )
         );
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSystemSettings($category, $reload = false)
+    {
+        $admin = \BeanFactory::getBean('Administration');
+        $admin->retrieveSettings($category, $reload);
+        return $admin->settings;
+    }
 }

--- a/src/Insulin/Sugar/SugarInterface.php
+++ b/src/Insulin/Sugar/SugarInterface.php
@@ -115,5 +115,20 @@ interface SugarInterface
      * @throws \RuntimeException
      *   If login fails.
      */
-    public function localLogin();
+    public function localLogin($username);
+
+    /**
+     * Gets the system settings from the Administration module.
+     *
+     * @param string $category
+     *   The category to get a slimmer payload.
+     * @param bool $reload
+     *   Reload data by skipping cache.
+     * @return array
+     *   All the settings cached due to bug on SugarCRM.
+     *
+     * TODO we should only get the category(ies) that we asked for.
+     * Currently we send information just like SugarCRM has it.
+     */
+    public function getSystemSettings($category, $reload = false);
 }


### PR DESCRIPTION
The status command should at least provide the following information for:
- BOOT_INSULIN
  - [x] PHP executable (works better on 5.4+)
  - [x] PHP configuration used (path to the current php.ini file)
  - [x] PHP OS information
  - [x] Insulin version
- BOOT_SUGAR_ROOT
  - [x] Sugar version (like s:v command)
  - [x] Sugar root (path)
- BOOT_SUGAR_CONFIGURATION
  - [x] DB information (driver, hostname, username, name)
  - [x] Database password hidden by default
  - [x] Cache directory path
  - [x] Site URI
  - [x] Upload directory path
  - [x] Developer mode (active, inactive)
  - [x] Logger level
  - [x] Logger file
- BOOT_SUGAR_DATABASE
  - [x] Database connection status (connected, failure, etc)
- BOOT_SUGAR_FULL
  - [x] DB version (from config table)
  - [x] License information
  - [x] License download key hidden by default
- BOOT_SUGAR_LOGIN
  - [ ] Sugar user (currently being used for the command)
### Needs discussion
- [x] Proxy requirements code to call version safe code?
- [x] Ability to print information in JSON format?
- [ ] Use keys instead and translate for table format? (format `license.users`, `database.username`, etc)
- [x] Sort data?
### Known issues
- [ ] Unit tests for code coverage
- [x] Provide safe configs (check `isset` or `empty`)

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #49 |
