### PR TITLE
Running insulin s:v -vvv -d on latest master gives fatal error

### DIFF
--- a/src/Insulin/Sugar/Sugar.php
+++ b/src/Insulin/Sugar/Sugar.php
@@ -250,8 +250,10 @@ abstract class Sugar implements SugarInterface
 
         if (empty($bean)) {
             throw new \RuntimeException(
-              sprintf("Unable to retrieve bean for '%s' module.", $module)
+                sprintf("Unable to retrieve bean for '%s' module.", $module)
             );
         }
+
+        return $bean;
     }
 }


### PR DESCRIPTION
When running:

``` bash
$ /Volumes/Trimurti/Works/PHP/insulin/cli2/insulin s:v -vvv -d
```

I get the following output:

```
Attempting to reach level '1'.
Reached level '1'.
Attempting to reach level '2'.
Reached level '2'.
Attempting to reach level '3'.
Loaded configurations.
Reached level '3'.
Attempting to reach level '4'.
Connected to database.
Reached level '4'.
Attempting to reach level '5'.
Reached level '5'.
Attempting to reach level '6'.
PHP Fatal error:  Call to a member function getSystemUser() on a non-object in insulin/cli2/src/Insulin/Sugar/Sugar.php on line 199

Fatal error: Call to a member function getSystemUser() on a non-object in insulin/cli2/src/Insulin/Sugar/Sugar.php on line 199
```
